### PR TITLE
Draft: bump Arrow to 1.2.0-RC

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -51,7 +51,7 @@ For **Kalidation** to work, you need to add the `arrow-core`, `jakarta-validatio
 Example for gradle:
 ```
 implementation("io.github.rcapraro:kalidation:1.9.1")
-implementation("io.arrow-kt:arrow-core:1.0.1")
+implementation("io.arrow-kt:arrow-core:1.2.0-RC")
 implementation("jakarta.validation:jakarta.validation-api:3.0.1")
 implementation("org.glassfish:jakarta.el:4.0.2")
 ```
@@ -98,13 +98,13 @@ val myClass = MyClass("BLUE", "foobar", LocalDateTime.parse("2017-12-03T10:15:30
 val validated = spec.validate(myClass) 
 ```
 
-In this example, `validated` is an [Arrow](https://arrow-kt.io) `Validated` object, which we can transform through Arrow
+In this example, `validated` is an [Arrow](https://arrow-kt.io) `Either` object, which we can transform through Arrow
 built-in functions: `when`, `fold`, `getOrElse`, `map`, etc.
 
 There is also an alternative validation-function called `validateNel`, which returns the Arrow
 type `NonEmptyList<ValidationResult>`.
 
-See [Arrow Validated](https://arrow-kt.io/docs/datatypes/validated/#validated) for more documentation.
+See [Arrow Validation](https://arrow-kt.io/learn/typed-errors/validation/) for more documentation.
 
 _Example with `fold`_:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.4.32"
+    kotlin("jvm") version "1.8.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("com.jfrog.bintray") version "1.8.5"
@@ -23,7 +23,7 @@ repositories {
 }
 
 val junitJupiterVersion = "5.8.2"
-val arrowVersion = "1.0.1"
+val arrowVersion = "1.2.0-RC"
 val jakartaBeanValidationVersion = "3.0.1"
 val jakartaElVersion = "4.0.0"
 val glassfishElVersion = "4.0.2"

--- a/src/main/kotlin/io/github/rcapraro/kalidation/dsl/ValidationDsl.kt
+++ b/src/main/kotlin/io/github/rcapraro/kalidation/dsl/ValidationDsl.kt
@@ -25,6 +25,7 @@
 package io.github.rcapraro.kalidation.dsl
 
 import arrow.core.NonEmptyList
+import arrow.core.toNonEmptyListOrNull
 import io.github.rcapraro.kalidation.exception.KalidationException
 import io.github.rcapraro.kalidation.implementation.HibernateValidatorFactory
 import io.github.rcapraro.kalidation.spec.ClassConstraint
@@ -61,11 +62,11 @@ fun <T : Any, P : Any?> ClassConstraint<T>.property(property: KProperty1<T, P>, 
     this.propertyConstraints.add(PropertyConstraint(property).apply(block))
 
 fun <T : Any, P : Collection<U?>, U : Any> PropertyConstraint<T, P>.eachElement(block: (@ValidationSpecMarker ContainerElementType<T, P, U>).() -> Unit) =
-    this.containerElementsTypes.add(ContainerElementType<T, P, U>(this.constrainedProperty, NonEmptyList.fromListUnsafe(listOf(0))).apply(block))
+    this.containerElementsTypes.add(ContainerElementType<T, P, U>(this.constrainedProperty, listOf(0).toNonEmptyListOrNull()!!).apply(block))
 
 fun <T : Any, P : Any?, U : Any> PropertyConstraint<T, P>.eachElement(
     type: KClass<U>,
-    indexes: NonEmptyList<Int> = NonEmptyList.fromListUnsafe(listOf(0)),
+    indexes: NonEmptyList<Int> = listOf(0).toNonEmptyListOrNull()!!,
     block: (@ValidationSpecMarker ContainerElementType<T, P, U>).() -> Unit
 ) = this.containerElementsTypes.add(ContainerElementType<T, P, U>(this.constrainedProperty, indexes).apply(block))
 

--- a/src/test/kotlin/ArrayValidationTest.kt
+++ b/src/test/kotlin/ArrayValidationTest.kt
@@ -27,7 +27,7 @@ class ArrayValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {

--- a/src/test/kotlin/BooleanValidationTest.kt
+++ b/src/test/kotlin/BooleanValidationTest.kt
@@ -24,7 +24,7 @@ class BooleanValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -48,7 +48,7 @@ class BooleanValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {

--- a/src/test/kotlin/CascadingValidationTest.kt
+++ b/src/test/kotlin/CascadingValidationTest.kt
@@ -71,7 +71,7 @@ class CascadingValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {

--- a/src/test/kotlin/CollectionValidationTest.kt
+++ b/src/test/kotlin/CollectionValidationTest.kt
@@ -28,7 +28,7 @@ class CollectionValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -52,7 +52,7 @@ class CollectionValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -76,7 +76,7 @@ class CollectionValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -100,7 +100,7 @@ class CollectionValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid)
+        assertThat(validated.isRight())
     }
 
     @Test
@@ -116,6 +116,6 @@ class CollectionValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid)
+        assertThat(validated.isRight())
     }
 }

--- a/src/test/kotlin/ContainerValidationTest.kt
+++ b/src/test/kotlin/ContainerValidationTest.kt
@@ -34,7 +34,7 @@ class ContainerValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -63,7 +63,7 @@ class ContainerValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {

--- a/src/test/kotlin/LocaleAndBundleValidationTest.kt
+++ b/src/test/kotlin/LocaleAndBundleValidationTest.kt
@@ -28,7 +28,7 @@ class LocaleAndBundleValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -57,7 +57,7 @@ class LocaleAndBundleValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -85,7 +85,7 @@ class LocaleAndBundleValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -110,7 +110,7 @@ class LocaleAndBundleValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {

--- a/src/test/kotlin/MapValidationTest.kt
+++ b/src/test/kotlin/MapValidationTest.kt
@@ -30,7 +30,7 @@ class MapValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {

--- a/src/test/kotlin/MethodValidationTest.kt
+++ b/src/test/kotlin/MethodValidationTest.kt
@@ -58,7 +58,7 @@ class MethodValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {

--- a/src/test/kotlin/NumberValidationTest.kt
+++ b/src/test/kotlin/NumberValidationTest.kt
@@ -46,7 +46,7 @@ class NumberValidationTest {
         val dslTest = NumberTestClass(3, BigDecimal("400.60"))
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {

--- a/src/test/kotlin/ScriptValidationTest.kt
+++ b/src/test/kotlin/ScriptValidationTest.kt
@@ -53,7 +53,7 @@ class ScriptValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid)
+        assertThat(validated.isRight())
     }
 
     @Test
@@ -71,7 +71,7 @@ class ScriptValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid)
+        assertThat(validated.isRight())
     }
 
     @Test
@@ -112,7 +112,7 @@ class ScriptValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid)
+        assertThat(validated.isRight())
     }
 
     @Test
@@ -153,6 +153,6 @@ class ScriptValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid)
+        assertThat(validated.isRight())
     }
 }

--- a/src/test/kotlin/StringValidationTest.kt
+++ b/src/test/kotlin/StringValidationTest.kt
@@ -67,7 +67,7 @@ class StringValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -120,7 +120,7 @@ class StringValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {
@@ -155,7 +155,7 @@ class StringValidationTest {
         val dslTest = StringTestClass("2018-06-15T17:32:28.000Z", "EmptyNotUsedForTest", "EmptyNotUsedForTest")
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid).isTrue
+        assertThat(validated.isRight()).isTrue
     }
 
     @Test
@@ -171,7 +171,7 @@ class StringValidationTest {
         val dslTest = StringTestClass(null, "EmptyNotUsedForTest", "EmptyNotUsedForTest")
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid).isTrue
+        assertThat(validated.isRight()).isTrue
     }
 
     @Test
@@ -187,7 +187,7 @@ class StringValidationTest {
         val dslTest = StringTestClass("", "EmptyNotUsedForTest", "EmptyNotUsedForTest")
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid).isTrue
+        assertThat(validated.isLeft()).isTrue
 
         validated.fold(
             {
@@ -231,7 +231,7 @@ class StringValidationTest {
         val dslTest = StringTestClass("2018-06-14T17:32:28.001Z", "EmptyNotUsedForTest", "EmptyNotUsedForTest")
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid).isTrue
+        assertThat(validated.isRight()).isTrue
     }
 
     @Test
@@ -247,7 +247,7 @@ class StringValidationTest {
         val dslTest = StringTestClass("2018-06-14T17:32:28.000Z", "EmptyNotUsedForTest", "EmptyNotUsedForTest")
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid).isTrue
+        assertThat(validated.isRight()).isTrue
     }
 
     @Test
@@ -263,7 +263,7 @@ class StringValidationTest {
         val dslTest = StringTestClass("2018-06-16T17:32:28.000Z", "EmptyNotUsedForTest", "EmptyNotUsedForTest")
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isValid).isTrue
+        assertThat(validated.isRight()).isTrue
     }
 
     @Test

--- a/src/test/kotlin/TemporalValidationTest.kt
+++ b/src/test/kotlin/TemporalValidationTest.kt
@@ -36,7 +36,7 @@ class TemporalValidationTest {
 
         val validated = spec.validate(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {

--- a/src/test/kotlin/ValidationWithNonEmptyListTest.kt
+++ b/src/test/kotlin/ValidationWithNonEmptyListTest.kt
@@ -27,7 +27,7 @@ class ValidationWithNonEmptyListTest {
 
         val validated = spec.validateNel(dslTest)
 
-        assertThat(validated.isInvalid)
+        assertThat(validated.isLeft())
 
         validated.fold(
             {


### PR DESCRIPTION
Closes #24 

Replaces `Validated` with `Either` and gets rid of deprecated `NonEmptyList.fromListUnsafe`.

Unfortunately(?) it looks like the new Arrow version also requires a newer Kotlin version. So I bumped it to use 1.8.20, too.